### PR TITLE
Gitignore and meaningful name to aquarium component containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vagrant
+data/*
+http-cache/*
+

--- a/bin/atlantis-aquarium
+++ b/bin/atlantis-aquarium
@@ -117,7 +117,9 @@ def start(component)
   else
     executer.run_in_vm!("rm -f #{cidfile}")
     docker_opts = "-d -t --cidfile #{cidfile} #{component.docker_opts}"
-    executer.run_in_vm!("docker run #{docker_opts} aquarium-#{component.name}")
+    name = "#{component.name}"
+    name = "#{name}-#{component.instance}" if component.instance
+    executer.run_in_vm!("docker run --name #{name} #{docker_opts} aquarium-#{component.name}")
 
     cid = File.read("#{component.directory}/#{cidfile}").chomp
     ip = executer.capture("docker inspect #{cid} | grep IPAddress | cut -d\\\" -f4")


### PR DESCRIPTION
Meaningful names as:
```
vagrant@atlantis-aquarium-vm:~$ docker ps -q | xargs docker inspect --format '{{printf "%.12s\t%s\t%s" .Id .Config.Image .Name}}'
0e88e0ced4b7	aquarium-supervisor	/supervisor-2
d0796a2f8c8a	aquarium-supervisor	/supervisor-1
1eda00ad675c	aquarium-router	/router-external
997936ea8094	aquarium-router	/router-internal
f024416a1a86	aquarium-manager	/manager
da1f847ab0b6	aquarium-builder	/builder
8f745a72db47	aquarium-registry	/registry
a5614f5bee58	aquarium-zookeeper	/zookeeper

```