### PR TITLE
Updated component container names with unique timestamp

### DIFF
--- a/bin/atlantis-aquarium
+++ b/bin/atlantis-aquarium
@@ -128,7 +128,7 @@ def start(component)
     executer.run_in_vm!("docker run --name #{name} #{docker_opts} aquarium-#{component.name}")
 
     cid = File.read("#{component.directory}/#{cidfile}").chomp
-    ip = executer.capture("docker inspect #{cid} | grep IPAddress | cut -d\\\" -f4")
+    ip = executer.capture("docker inspect --format '{{.NetworkSettings.IPAddress}}' #{cid}")
     File.write("#{component.directory}/#{ipfile}", ip)
     component.set_value("cid", cid.chomp)
     component.set_value("ip", ip.chomp)

--- a/bin/atlantis-aquarium
+++ b/bin/atlantis-aquarium
@@ -61,10 +61,10 @@ end
 # So we figure out where the command starts, and slice them out of ARGV before docopt.
 def preprocess_arguments_for_commands(args)
   # All arguments should be passed through to the atlantis command.
-  if args[0] == "atlantis"
+  if args.first == "atlantis"
     return args.slice!(1..-1)
   end
-  if args[0] == "ssh"
+  if args.first == "ssh"
     arg_index = 1
     arg_index += 1 if Component.names.include?(args[1]) # Skip <component>, if it exists
     while arg_index < args.length
@@ -101,6 +101,13 @@ def build_image(component, options)
   component.postimage.call(executer)
 end
 
+def get_container_name(component)
+  suffix = Time.now.strftime('%Y%m%d%H%M%S')
+  name = "#{component.name}-#{suffix}"
+  name.sub!(/^([^-]*-)/, "\\1#{component.instance}-") if component.instance
+  name
+end
+
 def start(component)
   return if component.name == "base-aquarium-image" # This one doesn't make sense to deploy.
   component.set_status("starting")
@@ -117,9 +124,7 @@ def start(component)
   else
     executer.run_in_vm!("rm -f #{cidfile}")
     docker_opts = "-d -t --cidfile #{cidfile} #{component.docker_opts}"
-    suffix = Time.now.strftime('%Y%m%d%H%M%S')
-    name = "#{component.name}-#{suffix}"
-    name.sub!(/^([^-]*-)/, "\\1#{component.instance}-") if component.instance
+    name = get_container_name(component)
     executer.run_in_vm!("docker run --name #{name} #{docker_opts} aquarium-#{component.name}")
 
     cid = File.read("#{component.directory}/#{cidfile}").chomp
@@ -340,9 +345,9 @@ if __FILE__ == $0
         system(trailing_args.join(" "))
       end
     else
-      components[0].each_instance(options["--instance"]) do |instance|
+      components.first.each_instance(options["--instance"]) do |instance|
         instance_name = instance.instance ? "-#{instance.instance}" : ""
-        puts "== ssh #{components[0].name}#{instance_name} =="
+        puts "== ssh #{components.first.name}#{instance_name} =="
         status = Status.read
         info = status[instance.name]
         info = info[instance.instance] if instance.instance

--- a/bin/atlantis-aquarium
+++ b/bin/atlantis-aquarium
@@ -117,8 +117,9 @@ def start(component)
   else
     executer.run_in_vm!("rm -f #{cidfile}")
     docker_opts = "-d -t --cidfile #{cidfile} #{component.docker_opts}"
-    name = "#{component.name}"
-    name = "#{name}-#{component.instance}" if component.instance
+    suffix = Time.now.strftime('%Y%m%d%H%M%S')
+    name = "#{component.name}-#{suffix}"
+    name.sub!(/^([^-]*-)/, "\\1#{component.instance}-") if component.instance
     executer.run_in_vm!("docker run --name #{name} #{docker_opts} aquarium-#{component.name}")
 
     cid = File.read("#{component.directory}/#{cidfile}").chomp

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -13,13 +13,9 @@ class Component
   #                 Remove when that transition completes.
   def wrap_in_function(operation)
     if operation.is_a?(Array) || operation.is_a?(String)
-      lambda do |executer|
-        executer.run_in_vm!(operation)
-      end
+      lambda { |executer| executer.run_in_vm!(operation) }
     else
-      lambda do |executer|
-        operation.call(self) if operation
-      end
+      lambda { |executer| operation.call(self) if operation }
     end
   end
 
@@ -37,14 +33,14 @@ class Component
     @postimage = wrap_in_function(options[:postimage])
     @prestart = wrap_in_function(options[:prestart])
     @poststart = wrap_in_function(options[:poststart])
+    @instances = {nil => self}
+
     if options[:instances]
       suboptions = options.dup
       suboptions.delete(:instances)
       @instances = Hash[options[:instances].map do |instance, instance_options|
         [instance, Component.new(name, suboptions.merge(instance_options).merge({instance: instance}))]
       end]
-    else
-      @instances = {nil => self}
     end
   end
 
@@ -74,11 +70,11 @@ class Component
   end
 
   def self.all
-    return @@components.values
+    @@components.values
   end
 
   def self.[](name, options = {})
-    return @@components[name]
+    @@components[name]
   end
 
   def self.names

--- a/lib/executer.rb
+++ b/lib/executer.rb
@@ -48,10 +48,7 @@ class Executer
   end
 
   def cd(path)
-    if path[0] == '/'
-      @cwd = path
-    else
-      @cwd += "/#{path}"
-    end
+    @cwd += "/#{path}"
+    @cwd = path if path[0] == '/'
   end
 end


### PR DESCRIPTION
Component names are updated with unique timestamp.

Names now:

```
aquarium-vm:~$ docker ps -q | xargs docker inspect --format '{{printf "%.12s\t%s\t%s" .Id .Config.Image .Name}}'
c8b9fc8b4743	aquarium-builder	/builder-20150923105438
8f37c22f5d01	aquarium-supervisor	/supervisor-1-20150923104817
463c7f16733d	aquarium-manager	/manager-20150923095313
5d585014f726	aquarium-router	    /router-external-20150923092611
b2e03a654f23	aquarium-router	    /router-internal-20150923092609
14e981b019bb	aquarium-registry	/registry-20150923090344
```

**Note:**
Cleanup few files.